### PR TITLE
Add CircleCI deploy config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,71 @@
+version: 2.1
+orbs:
+  aws-ecr: circleci/aws-ecr@6.7.0
+
+jobs:
+  test:
+    working_directory: ~/circle
+    docker:
+      - image: circleci/buildpack-deps:14.04
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run:
+          name: test
+          command: docker-compose run --rm app bundle exec rspec
+  deploy_staging:
+    working_directory: ~/circle/git/fb-base-adapter
+    docker: &ecr_base_image
+      - image: $AWS_BUILD_IMAGE_ECR_ACCOUNT_URL
+        aws_auth:
+          aws_access_key_id: $AWS_BUILD_IMAGE_ACCESS_KEY_ID
+          aws_secret_access_key: $AWS_BUILD_IMAGE_SECRET_ACCESS_KEY
+    steps:
+      - checkout
+      - setup_remote_docker
+      - add_ssh_keys:
+          fingerprints:
+            - "7e:e7:44:be:a1:4b:4e:3c:56:65:3a:94:19:50:02:cc"
+      - run:
+          name: deploy to staging
+          command: './deploy/scripts/circle_deploy.sh $CIRCLE_SHA1 staging $KUBE_TOKEN_STAGING'
+
+workflows:
+  version: 2
+  release:
+    jobs:
+      - test
+      - aws-ecr/build-and-push-image:
+          name: push_app_image
+          dockerfile: Dockerfile
+          account-url: AWS_ECR_ACCOUNT_URL
+          region: AWS_DEFAULT_REGION
+          repo: "form-builder/formbuilder-base-adapter"
+          tag: "APP_${CIRCLE_SHA1}"
+          filters:
+            branches:
+              only:
+                - master
+                - deploy-to-staging
+      - aws-ecr/build-and-push-image:
+          name: push_worker_image
+          dockerfile: Dockerfile.worker
+          account-url: AWS_ECR_ACCOUNT_URL
+          region: AWS_DEFAULT_REGION
+          repo: "form-builder/formbuilder-base-adapter"
+          tag: "WORKER_${CIRCLE_SHA1}"
+          filters:
+            branches:
+              only:
+                - master
+                - deploy-to-staging
+      - deploy_staging:
+          requires:
+            - push_app_image
+            - push_worker_image
+            - test
+          filters:
+            branches:
+              only:
+                - master
+                - deploy-to-staging

--- a/app.rb
+++ b/app.rb
@@ -23,3 +23,8 @@ rescue JWE::InvalidData
     { error: 'Failed to decrypt submission. Is the encryption key correct?' }
   )
 end
+
+get '/healthcheck' do
+  status 200
+  body 'healthy'
+end

--- a/deploy/Chart.yaml
+++ b/deploy/Chart.yaml
@@ -1,0 +1,3 @@
+apiVersion: v1
+name: formbuilder-base-adapter
+version: 0.0.1

--- a/deploy/scripts/circle_deploy.sh
+++ b/deploy/scripts/circle_deploy.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env sh
+
+set -e -u -o pipefail
+
+CONFIG_FILE="/tmp/helm_deploy.yaml"
+
+git_sha_tag=$1
+environment_name=$2
+kube_token=$3
+
+get_secrets() {
+    GIT_SSH_COMMAND='ssh -v -i ~/.ssh/id_rsa_7ee744bea14b4e3c56653a94195002cc -o "IdentitiesOnly=yes"' git clone git@github.com:ministryofjustice/formbuilder-base-adapter-deploy.git deploy-config
+    echo $ENCODED_GIT_CRYPT_KEY | base64 -d > /root/circle/git_crypt.key
+    cd deploy-config && git-crypt unlock /root/circle/git_crypt.key && cd -
+}
+
+deploy_with_secrets() {
+    echo -n "$KUBE_CERTIFICATE_AUTHORITY" | base64 -d > .kube_certificate_authority
+    kubectl config set-cluster "$KUBE_CLUSTER" --certificate-authority=".kube_certificate_authority" --server="$KUBE_SERVER"
+    kubectl config set-credentials "circleci_${environment_name}" --token="${kube_token}"
+    kubectl config set-context "circleci_${environment_name}" --cluster="$KUBE_CLUSTER" --user="circleci_${environment_name}" --namespace="formbuilder-base-adapter-${environment_name}"
+    kubectl config use-context "circleci_${environment_name}"
+
+    helm template deploy/ \
+         --set app_image_tag="APP_${git_sha_tag}" \
+         --set worker_image_tag="WORKER_${git_sha_tag}" \
+         --set environmentName=$environment_name \
+         > $CONFIG_FILE
+
+    echo "---" >> $CONFIG_FILE
+    cat deploy-config/secrets/${environment_name}_values.yaml >> $CONFIG_FILE
+
+    kubectl apply -f $CONFIG_FILE -n formbuilder-base-adapter-$environment_name
+}
+
+main() {
+    echo "Getting secrets"
+    get_secrets
+
+    echo "deploying ${environment_name}"
+    deploy_with_secrets
+}
+
+main

--- a/deploy/templates/deployment.yaml
+++ b/deploy/templates/deployment.yaml
@@ -1,0 +1,38 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: formbuilder-base-adapter
+spec:
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        app: formbuilder-base-adapter
+        appGroup: formbuilder-base-adapter
+    spec:
+      containers:
+      - name: formbuilder-base-adapter
+        image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/form-builder/formbuilder-base-adapter:{{ .Values.app_image_tag }}
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 4567
+        readinessProbe:
+          httpGet:
+            path: /health
+            port: 4567
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          successThreshold: 1
+        env:
+        - name: HOST
+          value: formbuilder-base-adapter-{{ .Values.environmentName }}.apps.live-1.cloud-platform.service.justice.gov.uk
+        - name: ENCRYPTION_KEY
+          valueFrom:
+            secretKeyRef:
+              name: formbuilder-base-adapter-secret
+              key: ENCRYPTION_KEY
+        - name: SENTRY_DSN
+          valueFrom:
+            secretKeyRef:
+              name: formbuilder-base-adapter-secret
+              key: SENTRY_DSN

--- a/deploy/templates/ingress.yaml
+++ b/deploy/templates/ingress.yaml
@@ -1,0 +1,16 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: formbuilder-base-adapter-{{ .Values.environmentName }}
+spec:
+  tls:
+    - hosts:
+        - formbuilder-base-adapter-{{ .Values.environmentName }}.apps.live-1.cloud-platform.service.justice.gov.uk
+  rules:
+  - host: formbuilder-base-adapter-{{ .Values.environmentName }}.apps.live-1.cloud-platform.service.justice.gov.uk
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: formbuilder-base-adapter
+          servicePort: 4567

--- a/deploy/templates/service.yaml
+++ b/deploy/templates/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: formbuilder-base-adapter
+  labels:
+    app: formbuilder-base-adapter
+spec:
+  ports:
+  - port: 4567
+    name: http
+    targetPort: 4567
+  selector:
+    app: formbuilder-base-adapter

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -52,4 +52,12 @@ describe '/submission' do
       expect(last_response.body).to eq(error)
     end
   end
+
+  context 'healthcheck' do
+    it 'returns 200 and healthy' do
+      get 'healthcheck'
+      expect(last_response.status).to be(200)
+      expect(last_response.body).to eq('healthy')
+    end
+  end
 end


### PR DESCRIPTION
We should only need to have the FB team GPG key available for decrypting the git-secrets and the sentry dsn. Hopefully.

Also add the healthcheck endpoint

https://trello.com/c/32QuD95Z/699-deploy-base-adapter-in-pentest-environment