### PR TITLE
Adjust circleci deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
       - setup_remote_docker
       - add_ssh_keys:
           fingerprints:
-            - "7e:e7:44:be:a1:4b:4e:3c:56:65:3a:94:19:50:02:cc"
+            - 'f4:ae:38:63:c0:71:e1:18:ef:44:22:29:3c:00:5a:3a'
       - run:
           name: deploy to test environment
           command: './deploy/scripts/circle_deploy.sh $CIRCLE_SHA1 test $KUBE_TOKEN_TEST'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,6 +45,8 @@ workflows:
           region: AWS_DEFAULT_REGION
           repo: "form-builder/formbuilder-base-adapter"
           tag: "APP_${CIRCLE_SHA1}"
+          requires:
+            - test
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,8 +15,8 @@ jobs:
           command: make build
       - run:
           name: test
-          command: make spec
-  deploy_staging:
+          command: make test
+  deploy_test:
     working_directory: ~/circle/git/fb-base-adapter
     docker: &ecr_base_image
       - image: $AWS_BUILD_IMAGE_ECR_ACCOUNT_URL
@@ -30,8 +30,8 @@ jobs:
           fingerprints:
             - "7e:e7:44:be:a1:4b:4e:3c:56:65:3a:94:19:50:02:cc"
       - run:
-          name: deploy to staging
-          command: './deploy/scripts/circle_deploy.sh $CIRCLE_SHA1 staging $KUBE_TOKEN_STAGING'
+          name: deploy to test environment
+          command: './deploy/scripts/circle_deploy.sh $CIRCLE_SHA1 test $KUBE_TOKEN_TEST'
 
 workflows:
   version: 2
@@ -49,8 +49,9 @@ workflows:
             branches:
               only:
                 - master
-                - deploy-to-staging
-      - deploy_staging:
+                - deploy-to-test
+                - adjust-circleci-deployment
+      - deploy_test:
           requires:
             - push_app_image
             - test
@@ -58,4 +59,5 @@ workflows:
             branches:
               only:
                 - master
-                - deploy-to-staging
+                - deploy-to-test
+                - adjust-circleci-deployment

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,7 +43,7 @@ workflows:
           dockerfile: Dockerfile
           account-url: AWS_ECR_ACCOUNT_URL
           region: AWS_DEFAULT_REGION
-          repo: "form-builder/formbuilder-base-adapter"
+          repo: 'formbuilder/fb-base-adapter'
           tag: "APP_${CIRCLE_SHA1}"
           requires:
             - test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,22 +47,9 @@ workflows:
               only:
                 - master
                 - deploy-to-staging
-      - aws-ecr/build-and-push-image:
-          name: push_worker_image
-          dockerfile: Dockerfile.worker
-          account-url: AWS_ECR_ACCOUNT_URL
-          region: AWS_DEFAULT_REGION
-          repo: "form-builder/formbuilder-base-adapter"
-          tag: "WORKER_${CIRCLE_SHA1}"
-          filters:
-            branches:
-              only:
-                - master
-                - deploy-to-staging
       - deploy_staging:
           requires:
             - push_app_image
-            - push_worker_image
             - test
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,8 +11,11 @@ jobs:
       - checkout
       - setup_remote_docker
       - run:
+          name: build
+          command: make build
+      - run:
           name: test
-          command: docker-compose run --rm app bundle exec rspec
+          command: make spec
   deploy_staging:
     working_directory: ~/circle/git/fb-base-adapter
     docker: &ecr_base_image

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,6 @@ workflows:
               only:
                 - master
                 - deploy-to-test
-                - adjust-circleci-deployment
       - deploy_test:
           requires:
             - push_app_image
@@ -62,4 +61,3 @@ workflows:
               only:
                 - master
                 - deploy-to-test
-                - adjust-circleci-deployment

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN bundle install --no-cache ${BUNDLE_ARGS}
 
 COPY --chown=appuser:appgroup . .
 
-ENV APP_PORT 3000
+ENV APP_PORT 4567
 EXPOSE $APP_PORT
 
 USER ${UID}

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+DOCKER_COMPOSE = docker-compose -f docker-compose.yml
+
+build:
+	$(DOCKER_COMPOSE) build --build-arg BUNDLE_ARGS=''
+
+test:
+	$(DOCKER_COMPOSE) run -e RAILS_ENV=test --rm app bundle exec rspec

--- a/app.rb
+++ b/app.rb
@@ -24,7 +24,7 @@ rescue JWE::InvalidData
   )
 end
 
-get '/healthcheck' do
+get '/health' do
   status 200
   body 'healthy'
 end

--- a/deploy/scripts/circle_deploy.sh
+++ b/deploy/scripts/circle_deploy.sh
@@ -23,8 +23,7 @@ deploy_with_secrets() {
        --set encryption_key=$encryption_key \
        > $CONFIG_FILE
 
-  cat $CONFIG_FILE
-#  kubectl apply -f $CONFIG_FILE -n formbuilder-base-adapter-$environment_name
+  kubectl apply -f $CONFIG_FILE -n formbuilder-base-adapter-$environment_name
 }
 
 main() {

--- a/deploy/scripts/circle_deploy.sh
+++ b/deploy/scripts/circle_deploy.sh
@@ -9,7 +9,7 @@ environment_name=$2
 k8s_token=$3
 
 get_secrets() {
-    GIT_SSH_COMMAND='ssh -v -i ~/.ssh/id_rsa_7ee744bea14b4e3c56653a94195002cc -o "IdentitiesOnly=yes"' git clone git@github.com:ministryofjustice/formbuilder-base-adapter-deploy.git deploy-config
+    GIT_SSH_COMMAND='ssh -v -i ~/.ssh/id_rsa_7ee744bea14b4e3c56653a94195002cc -o "IdentitiesOnly=yes"' git clone git@github.com:ministryofjustice/fb-base-adapter-deploy.git deploy-config
     echo $ENCODED_GIT_CRYPT_KEY | base64 -d > /root/circle/git_crypt.key
     cd deploy-config && git-crypt unlock /root/circle/git_crypt.key && cd -
 }

--- a/deploy/scripts/circle_deploy.sh
+++ b/deploy/scripts/circle_deploy.sh
@@ -6,7 +6,7 @@ CONFIG_FILE="/tmp/helm_deploy.yaml"
 
 git_sha_tag=$1
 environment_name=$2
-kube_token=$3
+k8s_token=$3
 
 get_secrets() {
     GIT_SSH_COMMAND='ssh -v -i ~/.ssh/id_rsa_7ee744bea14b4e3c56653a94195002cc -o "IdentitiesOnly=yes"' git clone git@github.com:ministryofjustice/formbuilder-base-adapter-deploy.git deploy-config
@@ -15,10 +15,10 @@ get_secrets() {
 }
 
 deploy_with_secrets() {
-    echo -n "$KUBE_CERTIFICATE_AUTHORITY" | base64 -d > .kube_certificate_authority
-    kubectl config set-cluster "$KUBE_CLUSTER" --certificate-authority=".kube_certificate_authority" --server="$KUBE_SERVER"
-    kubectl config set-credentials "circleci_${environment_name}" --token="${kube_token}"
-    kubectl config set-context "circleci_${environment_name}" --cluster="$KUBE_CLUSTER" --user="circleci_${environment_name}" --namespace="formbuilder-base-adapter-${environment_name}"
+    echo -n "$K8S_CLUSTER_CERT" | base64 -d > .kube_certificate_authority
+    kubectl config set-cluster "$K8S_CLUSTER_NAME" --certificate-authority=".kube_certificate_authority" --server="https://api.${K8S_CLUSTER_NAME}"
+    kubectl config set-credentials "circleci_${environment_name}" --token="${k8s_token}"
+    kubectl config set-context "circleci_${environment_name}" --cluster="$K8S_CLUSTER_NAME" --user="circleci_${environment_name}" --namespace="formbuilder-base-adapter-${environment_name}"
     kubectl config use-context "circleci_${environment_name}"
 
     helm template deploy/ \

--- a/deploy/scripts/circle_deploy.sh
+++ b/deploy/scripts/circle_deploy.sh
@@ -7,6 +7,7 @@ CONFIG_FILE="/tmp/helm_deploy.yaml"
 git_sha_tag=$1
 environment_name=$2
 k8s_token=$3
+encryption_key=$ENCRYPTION_KEY
 
 deploy_with_secrets() {
   echo -n "$K8S_CLUSTER_CERT" | base64 -d > .kube_certificate_authority

--- a/deploy/scripts/circle_deploy.sh
+++ b/deploy/scripts/circle_deploy.sh
@@ -9,7 +9,7 @@ environment_name=$2
 k8s_token=$3
 
 get_secrets() {
-    GIT_SSH_COMMAND='ssh -v -i ~/.ssh/id_rsa_7ee744bea14b4e3c56653a94195002cc -o "IdentitiesOnly=yes"' git clone git@github.com:ministryofjustice/fb-base-adapter-deploy.git deploy-config
+    GIT_SSH_COMMAND='ssh -v -i ~/.ssh/id_rsa_f4ae3863c071e118ef4422293c005a3a -o "IdentitiesOnly=yes"' git clone git@github.com:ministryofjustice/fb-base-adapter-deploy.git deploy-config
     echo $ENCODED_GIT_CRYPT_KEY | base64 -d > /root/circle/git_crypt.key
     cd deploy-config && git-crypt unlock /root/circle/git_crypt.key && cd -
 }

--- a/deploy/scripts/circle_deploy.sh
+++ b/deploy/scripts/circle_deploy.sh
@@ -8,37 +8,27 @@ git_sha_tag=$1
 environment_name=$2
 k8s_token=$3
 
-get_secrets() {
-    GIT_SSH_COMMAND='ssh -v -i ~/.ssh/id_rsa_f4ae3863c071e118ef4422293c005a3a -o "IdentitiesOnly=yes"' git clone git@github.com:ministryofjustice/fb-base-adapter-deploy.git deploy-config
-    echo $ENCODED_GIT_CRYPT_KEY | base64 -d > /root/circle/git_crypt.key
-    cd deploy-config && git-crypt unlock /root/circle/git_crypt.key && cd -
-}
-
 deploy_with_secrets() {
-    echo -n "$K8S_CLUSTER_CERT" | base64 -d > .kube_certificate_authority
-    kubectl config set-cluster "$K8S_CLUSTER_NAME" --certificate-authority=".kube_certificate_authority" --server="https://api.${K8S_CLUSTER_NAME}"
-    kubectl config set-credentials "circleci_${environment_name}" --token="${k8s_token}"
-    kubectl config set-context "circleci_${environment_name}" --cluster="$K8S_CLUSTER_NAME" --user="circleci_${environment_name}" --namespace="formbuilder-base-adapter-${environment_name}"
-    kubectl config use-context "circleci_${environment_name}"
+  echo -n "$K8S_CLUSTER_CERT" | base64 -d > .kube_certificate_authority
+  kubectl config set-cluster "$K8S_CLUSTER_NAME" --certificate-authority=".kube_certificate_authority" --server="https://api.${K8S_CLUSTER_NAME}"
+  kubectl config set-credentials "circleci_${environment_name}" --token="${k8s_token}"
+  kubectl config set-context "circleci_${environment_name}" --cluster="$K8S_CLUSTER_NAME" --user="circleci_${environment_name}" --namespace="formbuilder-base-adapter-${environment_name}"
+  kubectl config use-context "circleci_${environment_name}"
 
-    helm template deploy/ \
-         --set app_image_tag="APP_${git_sha_tag}" \
-         --set worker_image_tag="WORKER_${git_sha_tag}" \
-         --set environmentName=$environment_name \
-         > $CONFIG_FILE
+  helm template deploy/ \
+       --set app_image_tag="APP_${git_sha_tag}" \
+       --set worker_image_tag="WORKER_${git_sha_tag}" \
+       --set environmentName=$environment_name \
+       --set encryption_key=$encryption_key \
+       > $CONFIG_FILE
 
-    echo "---" >> $CONFIG_FILE
-    cat deploy-config/secrets/${environment_name}_values.yaml >> $CONFIG_FILE
-
-    kubectl apply -f $CONFIG_FILE -n formbuilder-base-adapter-$environment_name
+  cat $CONFIG_FILE
+#  kubectl apply -f $CONFIG_FILE -n formbuilder-base-adapter-$environment_name
 }
 
 main() {
-    echo "Getting secrets"
-    get_secrets
-
-    echo "deploying ${environment_name}"
-    deploy_with_secrets
+ echo "Deploying ${environment_name}"
+ deploy_with_secrets
 }
 
 main

--- a/deploy/templates/deployment.yaml
+++ b/deploy/templates/deployment.yaml
@@ -31,8 +31,3 @@ spec:
             secretKeyRef:
               name: fb-base-adapter-app-secrets-{{ .Values.environmentName }}
               key: encryption_key
-        - name: SENTRY_DSN
-          valueFrom:
-            secretKeyRef:
-              name: fb-base-adapter-app-secrets-{{ .Values.environmentName }}
-              key: sentry_dsn

--- a/deploy/templates/deployment.yaml
+++ b/deploy/templates/deployment.yaml
@@ -29,10 +29,10 @@ spec:
         - name: ENCRYPTION_KEY
           valueFrom:
             secretKeyRef:
-              name: formbuilder-base-adapter-secret
+              name: fb-base-adapter-app-secrets-{{ .Values.environmentName }}
               key: ENCRYPTION_KEY
         - name: SENTRY_DSN
           valueFrom:
             secretKeyRef:
-              name: formbuilder-base-adapter-secret
+              name: fb-base-adapter-app-secrets-{{ .Values.environmentName }}
               key: SENTRY_DSN

--- a/deploy/templates/deployment.yaml
+++ b/deploy/templates/deployment.yaml
@@ -30,9 +30,9 @@ spec:
           valueFrom:
             secretKeyRef:
               name: fb-base-adapter-app-secrets-{{ .Values.environmentName }}
-              key: ENCRYPTION_KEY
+              key: encryption_key
         - name: SENTRY_DSN
           valueFrom:
             secretKeyRef:
               name: fb-base-adapter-app-secrets-{{ .Values.environmentName }}
-              key: SENTRY_DSN
+              key: sentry_dsn

--- a/deploy/templates/deployment.yaml
+++ b/deploy/templates/deployment.yaml
@@ -12,7 +12,7 @@ spec:
     spec:
       containers:
       - name: formbuilder-base-adapter
-        image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/form-builder/formbuilder-base-adapter:{{ .Values.app_image_tag }}
+        image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/formbuilder/fb-base-adapter:{{ .Values.app_image_tag }}
         imagePullPolicy: Always
         ports:
         - containerPort: 4567

--- a/deploy/templates/secrets.yaml
+++ b/deploy/templates/secrets.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: fb-base-adapter-app-secrets
+  name: fb-base-adapter-app-secrets-{{ .Values.environmentName }}
 type: Opaque
 data:
   encryption_key: {{ .Values.encryption_key }}

--- a/deploy/templates/secrets.yaml
+++ b/deploy/templates/secrets.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: fb-base-adapter-app-secrets
+type: Opaque
+data:
+  encryption_key: {{ .Values.encryption_key }}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+version: '3.4'
+
+services:
+  app:
+    build:
+      context: .
+      args:
+        RAILS_ENV: 'test'
+        BUNDLE_FLAGS: '--jobs 4 --no-cache'
+    environment:
+      ENCRYPTION_KEY: '1234567890123456'
+    ports:
+      - '4567:3000'

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -53,9 +53,9 @@ describe '/submission' do
     end
   end
 
-  context 'healthcheck' do
+  context 'health check' do
     it 'returns 200 and healthy' do
-      get 'healthcheck'
+      get 'health'
       expect(last_response.status).to be(200)
       expect(last_response.body).to eq('healthy')
     end


### PR DESCRIPTION
[Trello Card](https://trello.com/c/32QuD95Z/699-deploy-base-adapter-in-pentest-environment)

## Context

This PR setup the configuration for Kubernetes, CircleCI and the docker container.

After the PR is merged the application can be tested on CircleCI, deploy to kubernetes on the test environment and push the image to AWS ECR.