### PR TITLE
Api/v2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-tmp/payload_content.json
+tmp/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,5 +24,4 @@ ENV APP_PORT 4567
 EXPOSE $APP_PORT
 
 USER ${UID}
-
-CMD APP_ENV=production bundle exec ruby app.rb -p ${APP_PORT}
+CMD ./start.sh

--- a/Gemfile
+++ b/Gemfile
@@ -2,9 +2,11 @@ source 'https://rubygems.org'
 
 gem 'jwe', '~> 0.4.0'
 gem 'pry'
+gem 'rufus-scheduler'
 gem 'sinatra'
 gem 'sinatra-contrib'
 gem 'thin'
+gem 'tzinfo-data'
 gem 'uuid'
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ gem 'pry'
 gem 'sinatra'
 gem 'sinatra-contrib'
 gem 'thin'
+gem 'uuid'
 
 group :test do
   gem 'rack-test'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,6 +7,8 @@ GEM
     diff-lcs (1.3)
     eventmachine (1.2.7)
     jwe (0.4.0)
+    macaddr (1.7.2)
+      systemu (~> 2.6.5)
     method_source (1.0.0)
     multi_json (1.14.1)
     mustermann (1.1.1)
@@ -45,11 +47,14 @@ GEM
       rack-protection (= 2.0.8.1)
       sinatra (= 2.0.8.1)
       tilt (~> 2.0)
+    systemu (2.6.5)
     thin (1.7.2)
       daemons (~> 1.0, >= 1.0.9)
       eventmachine (~> 1.0, >= 1.0.4)
       rack (>= 1, < 3)
     tilt (2.0.10)
+    uuid (2.3.9)
+      macaddr (~> 1.0)
 
 PLATFORMS
   ruby
@@ -62,6 +67,7 @@ DEPENDENCIES
   sinatra
   sinatra-contrib
   thin
+  uuid
 
 BUNDLED WITH
    2.1.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,9 +3,15 @@ GEM
   specs:
     backports (3.17.2)
     coderay (1.1.3)
+    concurrent-ruby (1.1.6)
     daemons (1.3.1)
     diff-lcs (1.3)
+    et-orbi (1.2.4)
+      tzinfo
     eventmachine (1.2.7)
+    fugit (1.3.7)
+      et-orbi (~> 1.1, >= 1.1.8)
+      raabro (~> 1.3)
     jwe (0.4.0)
     macaddr (1.7.2)
       systemu (~> 2.6.5)
@@ -16,6 +22,7 @@ GEM
     pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
+    raabro (1.3.1)
     rack (2.2.3)
     rack-protection (2.0.8.1)
       rack
@@ -35,6 +42,8 @@ GEM
       rspec-support (~> 3.9.0)
     rspec-support (3.9.3)
     ruby2_keywords (0.0.2)
+    rufus-scheduler (3.6.0)
+      fugit (~> 1.1, >= 1.1.6)
     sinatra (2.0.8.1)
       mustermann (~> 1.0)
       rack (~> 2.0)
@@ -53,6 +62,10 @@ GEM
       eventmachine (~> 1.0, >= 1.0.4)
       rack (>= 1, < 3)
     tilt (2.0.10)
+    tzinfo (2.0.2)
+      concurrent-ruby (~> 1.0)
+    tzinfo-data (1.2020.1)
+      tzinfo (>= 1.0.0)
     uuid (2.3.9)
       macaddr (~> 1.0)
 
@@ -64,9 +77,11 @@ DEPENDENCIES
   pry
   rack-test
   rspec
+  rufus-scheduler
   sinatra
   sinatra-contrib
   thin
+  tzinfo-data
   uuid
 
 BUNDLED WITH

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is used for simulating the potential JSON endpoint adapters that integrate 
 
 ## Mechanism
 
-The base adapter receives submissions adn store temporarily into a file.
+The base adapter receives submissions and stores them temporarily as files.
 This file is deleted everyday at a specific time.
 
 ## API

--- a/README.md
+++ b/README.md
@@ -1,3 +1,14 @@
 # Form Builder Base Adapter
 
 This is used for simulating the potential JSON endpoint adapters that integrate with the Form Builder platform.
+
+## Mechanism
+
+The base adapter receives submissions adn store temporarily into a file.
+This file is deleted everyday at a specific time.
+
+## API
+
+1. POST /submission
+2. GET /submission (latest submission)
+3. GET /submission/:id (get the submission by a specific ID)

--- a/app.rb
+++ b/app.rb
@@ -4,6 +4,7 @@ require 'sinatra/json'
 require 'pry'
 require 'jwe'
 require 'securerandom'
+require 'uuid'
 
 PAYLOAD_CONTENT_FILE = 'tmp/payload_content.json'
 
@@ -37,7 +38,12 @@ get '/submission' do
 end
 
 get '/submission/:id' do
-  read_payload_file("tmp/#{params[:id]}")
+  if UUID.validate(params[:id])
+    read_payload_file("tmp/#{params[:id]}")
+  else
+    status 400
+    json({ error: 'Submission id should be a valid UUID' })
+  end
 end
 
 get '/health' do

--- a/app.rb
+++ b/app.rb
@@ -3,25 +3,41 @@ require 'json'
 require 'sinatra/json'
 require 'pry'
 require 'jwe'
+require 'securerandom'
 
 PAYLOAD_CONTENT_FILE = 'tmp/payload_content.json'
 
+helpers do
+  def read_payload_file(filename)
+    encrypted_payload = File.read(filename)
+    JWE.decrypt(encrypted_payload, ENV['ENCRYPTION_KEY'])
+  rescue Errno::ENOENT
+    status 404
+    json({ error: 'Submission not found' })
+  rescue JWE::InvalidData
+    status 400
+    json(
+      { error: 'Failed to decrypt submission. Is the encryption key correct?' }
+    )
+  end
+end
+
 post '/submission' do
   payload = request.body.read
-  File.write(PAYLOAD_CONTENT_FILE, payload)
+  uuid = SecureRandom.uuid
+  ["tmp/#{uuid}", PAYLOAD_CONTENT_FILE].each do |filename|
+    File.write(filename, payload)
+  end
+  status 201
+  headers['Location'] = "/submission/#{uuid}"
 end
 
 get '/submission' do
-  encrypted_payload = File.read(PAYLOAD_CONTENT_FILE)
-  JWE.decrypt(encrypted_payload, ENV['ENCRYPTION_KEY'])
-rescue Errno::ENOENT
-  status 404
-  json({ error: 'Submission not found' })
-rescue JWE::InvalidData
-  status 400
-  json(
-    { error: 'Failed to decrypt submission. Is the encryption key correct?' }
-  )
+  read_payload_file(PAYLOAD_CONTENT_FILE)
+end
+
+get '/submission/:id' do
+  read_payload_file("tmp/#{params[:id]}")
 end
 
 get '/health' do

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -2,58 +2,77 @@ require 'spec_helper'
 require 'jwe'
 require 'securerandom'
 
-describe '/submission' do
+describe 'Submissions' do
   let(:payload) { "{\"foo\": \"bar\"}" }
 
-  context 'when there is a submission' do
-    let(:encryption_key) { SecureRandom.uuid[0..15] }
-    before do
-      allow(ENV).to receive(:[]).with('ENCRYPTION_KEY').and_return(encryption_key)
-    end
+  describe 'post /submission' do
+    context 'when there is a submission' do
+      let(:encryption_key) { SecureRandom.uuid[0..15] }
+      before do
+        allow(ENV).to receive(:[]).with('ENCRYPTION_KEY').and_return(encryption_key)
+      end
 
-    context 'when the encryption key is the same as the payload' do
-      let(:encrypted_payload) { JWE.encrypt(payload, encryption_key, alg: 'dir') }
+      context 'when the encryption key is the same as the payload' do
+        let(:encrypted_payload) { JWE.encrypt(payload, encryption_key, alg: 'dir') }
+        let(:filename) { 'formatron' }
 
-      it 'returns the submission payload' do
-        post '/submission', encrypted_payload
+        before do
+          allow(SecureRandom).to receive(:uuid).and_return(filename)
+          post '/submission', encrypted_payload
+        end
 
-        get '/submission'
-        expect(last_response.body).to eq(payload)
+        it 'returns created status' do
+          expect(last_response.status).to be(201)
+        end
+
+        it 'returns resource location' do
+          expect(
+            last_response.headers
+          ).to include('Location' => '/submission/formatron')
+          get '/submission/formatron'
+          expect(last_response.status).to be(200)
+          expect(last_response.body).to eq(payload)
+        end
+
+        it 'returns the submission payload' do
+          get '/submission'
+          expect(last_response.body).to eq(payload)
+        end
+      end
+
+      context 'when the encryption key is NOT the same as the payload' do
+        let(:encrypted_payload) { JWE.encrypt(payload, 'a' * 16, alg: 'dir') }
+        let(:error) do
+          JSON.generate(
+            error: 'Failed to decrypt submission. Is the encryption key correct?'
+          )
+        end
+
+        it 'returns the submission payload' do
+          post '/submission', encrypted_payload
+          get '/submission'
+          expect(last_response.status).to be(400)
+          expect(last_response.body).to eq(error)
+        end
       end
     end
 
-    context 'when the encryption key is NOT the same as the payload' do
-      let(:encrypted_payload) { JWE.encrypt(payload, 'a' * 16, alg: 'dir') }
-      let(:error) do
-        JSON.generate(
-          error: 'Failed to decrypt submission. Is the encryption key correct?'
-        )
+    context 'when there is no submission' do
+      let(:error) { JSON.generate(error: 'Submission not found') }
+
+      before do
+        File.delete(PAYLOAD_CONTENT_FILE) if File.exist?(PAYLOAD_CONTENT_FILE)
       end
 
-      it 'returns the submission payload' do
-        post '/submission', encrypted_payload
+      it 'returns not found' do
         get '/submission'
-        expect(last_response.status).to be(400)
+        expect(last_response.status).to be(404)
         expect(last_response.body).to eq(error)
       end
     end
   end
 
-  context 'when there is no submission' do
-    let(:error) { JSON.generate(error: 'Submission not found') }
-
-    before do
-      File.delete(PAYLOAD_CONTENT_FILE) if File.exist?(PAYLOAD_CONTENT_FILE)
-    end
-
-    it 'returns not found' do
-      get '/submission'
-      expect(last_response.status).to be(404)
-      expect(last_response.body).to eq(error)
-    end
-  end
-
-  context 'health check' do
+  describe 'health check' do
     it 'returns 200 and healthy' do
       get 'health'
       expect(last_response.status).to be(200)

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -6,15 +6,16 @@ describe 'Submissions' do
   let(:payload) { "{\"foo\": \"bar\"}" }
 
   describe 'post /submission' do
-    context 'when there is a submission' do
-      let(:encryption_key) { SecureRandom.uuid[0..15] }
-      before do
-        allow(ENV).to receive(:[]).with('ENCRYPTION_KEY').and_return(encryption_key)
-      end
+    let(:encryption_key) { SecureRandom.uuid[0..15] }
 
+    before do
+      allow(ENV).to receive(:[]).with('ENCRYPTION_KEY').and_return(encryption_key)
+    end
+
+    context 'when there is a submission' do
       context 'when the encryption key is the same as the payload' do
         let(:encrypted_payload) { JWE.encrypt(payload, encryption_key, alg: 'dir') }
-        let(:filename) { 'formatron' }
+        let(:filename) { 'eec1fa01-7c37-4c85-a1c7-b1c0ce649f8c' }
 
         before do
           allow(SecureRandom).to receive(:uuid).and_return(filename)
@@ -26,10 +27,10 @@ describe 'Submissions' do
         end
 
         it 'returns resource location' do
-          expect(
-            last_response.headers
-          ).to include('Location' => '/submission/formatron')
-          get '/submission/formatron'
+          expect(last_response.headers).to include(
+            'Location' => '/submission/eec1fa01-7c37-4c85-a1c7-b1c0ce649f8c'
+          )
+          get '/submission/eec1fa01-7c37-4c85-a1c7-b1c0ce649f8c'
           expect(last_response.status).to be(200)
           expect(last_response.body).to eq(payload)
         end
@@ -67,6 +68,18 @@ describe 'Submissions' do
       it 'returns not found' do
         get '/submission'
         expect(last_response.status).to be(404)
+        expect(last_response.body).to eq(error)
+      end
+    end
+
+    context 'when try to find a submission with invalid UUID' do
+      let(:error) do
+        JSON.generate(error: 'Submission id should be a valid UUID')
+      end
+
+      it 'returns not found' do
+        get '/submission/formatron'
+        expect(last_response.status).to be(400)
         expect(last_response.body).to eq(error)
       end
     end

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env sh
+set -x
+
+export APP_ENV=production
+
+bundle exec ruby sweeper.rb &
+bundle exec ruby app.rb -p ${APP_PORT}

--- a/sweeper.rb
+++ b/sweeper.rb
@@ -1,0 +1,14 @@
+require 'rufus-scheduler'
+
+scheduler = Rufus::Scheduler.new
+
+logger = Logger.new('./sweeper.log')
+
+# At 06:00.
+scheduler.cron '* 06 * * *' do
+  files = Dir['tmp/*']
+  logger.info("Sweeping files: #{files.join(',')}")
+  FileUtils.rm_rf(files)
+end
+
+scheduler.join


### PR DESCRIPTION
[Trello Card](https://trello.com/c/k7L3RLpD/829-change-acceptance-tests-to-use-json-base-adapter)

## Context

The goal of the card is to point the acceptance test JSON form to point to our base adapter. In order to accomplish this the current PR adds an endpoint `/submission/:id` in order to the test verifies the json that was sent to the adapter.

This is the first part of the work. The second part involves changes the test to request to this API.

Endpoints:

1. POST /submission
2. GET /submission (latest submission)
3. GET /submission/:id (specific submission)
