### PR TITLE
Add DELETE submissions

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -21,6 +21,15 @@ helpers do
       { error: 'Failed to decrypt submission. Is the encryption key correct?' }
     )
   end
+
+  def with_valid_uuid
+    if UUID.validate(params[:id])
+      yield
+    else
+      status 400
+      json({ error: 'Submission id should be a valid UUID' })
+    end
+  end
 end
 
 post '/submission' do
@@ -38,12 +47,13 @@ get '/submission' do
 end
 
 get '/submission/:id' do
-  if UUID.validate(params[:id])
+  with_valid_uuid do
     read_payload_file("tmp/#{params[:id]}")
-  else
-    status 400
-    json({ error: 'Submission id should be a valid UUID' })
   end
+end
+
+delete '/submissions' do
+  FileUtils.rm_rf(Dir['tmp/*'])
 end
 
 get '/health' do

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -39,6 +39,12 @@ describe 'Submissions' do
           get '/submission'
           expect(last_response.body).to eq(payload)
         end
+
+        it 'deletes submission' do
+          delete '/submissions'
+          get '/submission'
+          expect(last_response.status).to be(404)
+        end
       end
 
       context 'when the encryption key is NOT the same as the payload' do


### PR DESCRIPTION
The acceptance tests verifies the latest submission so we need
to guarantee that we are checking the latest and not an old
version.

There still the sweeper and I am deciding to keep it anyway because it always good to clean in case we are manually pointing to the base adapter.