### PR TITLE
Decrease the level of the pods to one

### DIFF
--- a/deploy/templates/deployment.yaml
+++ b/deploy/templates/deployment.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: formbuilder-base-adapter
 spec:
-  replicas: 2
+  replicas: 1
   selector:
     matchLabels:
       app: formbuilder-base-adapter


### PR DESCRIPTION
## Context

Currently, we have two pods.

If the submissions is written in one but not in the other, the submission won’t be there when it goes to the wrong pod. 
So for now decreasing to one pod to make sure acceptance tests are stable.