### PR TITLE
Remove fingerprint from acceptance tests step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,9 +53,6 @@ jobs:
     working_directory: ~/circle/git/fb-base-adapter
     docker: *ecr_image
     steps:
-      - add_ssh_keys:
-          fingerprints:
-            - "f4:ae:38:63:c0:71:e1:18:ef:44:22:29:3c:00:5a:3a"
       - run:
           name: cloning deploy scripts
           command: 'git clone git@github.com:ministryofjustice/fb-deploy.git deploy-scripts'


### PR DESCRIPTION
The fb-deploy repo is public and there are no other private repos that need to be cloned in the trigger acceptance tests step.