### PR TITLE
Run acceptance tests in their own step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,4 @@
 version: 2.1
-orbs:
-  aws-ecr: circleci/aws-ecr@6.7.0
-
 jobs:
   tests:
     working_directory: ~/circle
@@ -34,7 +31,7 @@ jobs:
           command: |
             echo "export BUILD_SHA=$CIRCLE_SHA1" >> $BASH_ENV
             echo "export SSH_FILE_FOR_SECRETS=~/.ssh/id_rsa_f4ae3863c071e118ef4422293c005a3a" >> $BASH_ENV
-      - run:
+      - run: &deploy_scripts
           name: cloning deploy scripts
           command: 'git clone git@github.com:ministryofjustice/fb-deploy.git deploy-scripts'
       - run:
@@ -49,15 +46,14 @@ jobs:
             PLATFORM_ENV: test
             K8S_NAMESPACE: formbuilder-base-adapter-test
           command: './deploy-scripts/bin/deploy'
-  trigger_acceptance_tests:
-    working_directory: ~/circle/git/fb-base-adapter
+  acceptance_tests:
     docker: *ecr_image
+    resource_class: large
     steps:
+      - setup_remote_docker
+      - run: *deploy_scripts
       - run:
-          name: cloning deploy scripts
-          command: 'git clone git@github.com:ministryofjustice/fb-deploy.git deploy-scripts'
-      - run:
-          name: "Trigger Acceptance Tests"
+          name: Run acceptance tests
           command: './deploy-scripts/bin/acceptance_tests'
 
 workflows:
@@ -73,7 +69,7 @@ workflows:
               only:
                 - master
                 - deploy-to-test
-      - trigger_acceptance_tests:
+      - acceptance_tests:
           requires:
             - build_and_deploy_to_test
           filters:


### PR DESCRIPTION
We do not want to trigger the acceptance tests via the API any more.

https://trello.com/c/BxIV1rkx/931-make-acceptance-tests-run-inside-each-deployment