### PR TITLE
Notify slack on deployment failures and successes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,7 @@
 version: 2.1
+orbs:
+  slack: circleci/slack@3.4.2
+
 jobs:
   tests:
     working_directory: ~/circle
@@ -13,6 +16,11 @@ jobs:
       - run:
           name: test
           command: make test
+      - slack/status: &slack_status
+          fail_only: true
+          only_for_branches: master
+          failure_message: ":facepalm:  Failed job $CIRCLE_JOB  :homer-disappear:"
+          include_job_number_field: false
   build_and_deploy_to_test:
     working_directory: ~/circle/git/fb-base-adapter
     docker: &ecr_image
@@ -46,6 +54,7 @@ jobs:
             PLATFORM_ENV: test
             K8S_NAMESPACE: formbuilder-base-adapter-test
           command: './deploy-scripts/bin/deploy'
+      - slack/status: *slack_status
   acceptance_tests:
     docker: *ecr_image
     resource_class: large
@@ -55,6 +64,11 @@ jobs:
       - run:
           name: Run acceptance tests
           command: './deploy-scripts/bin/acceptance_tests'
+      - slack/status:
+          only_for_branches: master
+          success_message: ":rocket:  Successfully deployed to Test  :guitar:"
+          failure_message: ":facepalm:  Acceptance tests failed  :homer-disappear:"
+          include_job_number_field: false
 
 workflows:
   version: 2


### PR DESCRIPTION
Moving the acceptance tests into each deployment has removed the notification that happens when they fail as it's not actually the circleci job that is running anymore.

We require notifications to be sent to the #form-builder-deployments channel on failure of acceptance tests.

Also on failure to deploy to test

Also on a successful deploy to test

https://trello.com/c/myuOzEs3/933-notify-slack-when-deployments-fail-succeed