### PR TITLE
Increase initialDelaySeconds

### DIFF
--- a/deploy/fb-base-adapter-chart/templates/deployment.yaml
+++ b/deploy/fb-base-adapter-chart/templates/deployment.yaml
@@ -24,7 +24,7 @@ spec:
           httpGet:
             path: /health
             port: 4567
-          initialDelaySeconds: 5
+          initialDelaySeconds: 15
           periodSeconds: 5
           successThreshold: 1
         env:


### PR DESCRIPTION
This is to give Kubernetes a bit more time before allowing
network connections to be routed to the container