### PR TITLE
Add ingress annotations to kubernetes configuration

### DIFF
--- a/deploy/fb-base-adapter-chart/templates/ingress.yaml
+++ b/deploy/fb-base-adapter-chart/templates/ingress.yaml
@@ -2,6 +2,9 @@ apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: fb-base-adapter-{{ .Values.environmentName }}
+  annotations:
+    external-dns.alpha.kubernetes.io/set-identifier: "fb-base-adapter-{{ .Values.environmentName }}-formbuilder-base-adapter-{{ .Values.environmentName }}-blue"
+    external-dns.alpha.kubernetes.io/aws-weight: "100"
 spec:
   tls:
     - hosts:


### PR DESCRIPTION
This is necessary for the upcoming EKS migration work.

Co-authored-by: Natalie Seeto <natalie.seeto@digital.justice.gov.uk>