### PR TITLE
Use circleci convenience images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
   tests:
     working_directory: ~/circle
     docker:
-      - image: circleci/buildpack-deps:14.04
+      - image: cimg/ruby:2.7.5
     steps:
       - checkout
       - setup_remote_docker


### PR DESCRIPTION
circleci/ images are deprecated.

`buildpack-deps` has been deprecated entirely so there is no convenience image equivalent to move to. that step is only used in running the tests so a ruby 2.7.5 container will do the job as this is just a very small sinatra app.