### PR TITLE
Stop using the beta versions of kubernetes ingress controllers

### DIFF
--- a/deploy-eks/fb-base-adapter-chart/templates/ingress.yaml
+++ b/deploy-eks/fb-base-adapter-chart/templates/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: fb-base-adapter-{{ .Values.environmentName }}
@@ -15,6 +15,9 @@ spec:
     http:
       paths:
       - path: /
+        pathType: ImplementationSpecific
         backend:
-          serviceName: formbuilder-base-adapter
-          servicePort: 4567
+          service:
+            name: formbuilder-base-adapter
+            port:
+              number: 4567


### PR DESCRIPTION
All beta Ingress API versions such as extensions/v1beta1 and networking.k8s.io/v1beta1 have been deprecated and are not available in Kubernetes v1.22 or the new nginx-ingress-controller v1.2

Change the apiVersion to networking.k8s.io/v1

Add pathType: ImplementationSpecific after path: /

For serviceName, rename -backend.serviceName to -backend.service.name

For String servicePort, rename -backend.servicePort to -backend.service.port.name

For Numeric servicePort, rename -backend.servicePort to -backend.service.port.number