### PR TITLE
Add checkout step in acceptance test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,6 +59,7 @@ jobs:
     docker: *ecr_image
     resource_class: large
     steps:
+      - checkout
       - setup_remote_docker
       - run: *deploy_scripts
       - run:


### PR DESCRIPTION
Failing to clone the deploy scripts from the fb-deploy repo due to issues with the RSA host key for github.
Add the checkout step as this automatically adds the authenticating key required to interact with GitHub.